### PR TITLE
ci: add "build" workflows

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -27,6 +27,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: './server/package-lock.json'
-      - run: |
-          npm ci
-          npm run build
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,0 +1,24 @@
+name: Build Backend (Server)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: cd ./server
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -28,6 +28,5 @@ jobs:
           cache: 'npm'
           cache-dependency-path: './server/package-lock.json'
       - run: |
-          cd ./server
           npm ci
           npm run build

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: cd ./server
-      - run: npm ci
-      - run: npm run build
+      - run: |
+          cd ./server
+          npm ci
+          npm run build

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -6,8 +6,14 @@ on:
       - main
 
 jobs:
-  build-job:
+  build-backend:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: './server'
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -15,10 +21,12 @@ jobs:
           fetch-depth: 0
           clean: true
 
-      - uses: actions/setup-node@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: './server/package-lock.json'
       - run: |
           cd ./server
           npm ci

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,24 @@
+name: Build Frontend (Client)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: cd ./client
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -27,6 +27,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: './client/package-lock.json'
-      - run: |
-          npm ci
-          npm run build
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -6,8 +6,14 @@ on:
       - main
 
 jobs:
-  build-job:
+  build-frontend:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: './client'
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -15,10 +21,12 @@ jobs:
           fetch-depth: 0
           clean: true
 
-      - uses: actions/setup-node@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: './client/package-lock.json'
       - run: |
           cd ./client
           npm ci

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -28,6 +28,5 @@ jobs:
           cache: 'npm'
           cache-dependency-path: './client/package-lock.json'
       - run: |
-          cd ./client
           npm ci
           npm run build

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: cd ./client
-      - run: npm ci
-      - run: npm run build
+      - run: |
+          cd ./client
+          npm ci
+          npm run build


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows to automate the build processes for both the backend and frontend of the project. The key changes include the addition of separate workflows for building the server and client components upon pull requests to the main branch.

### New GitHub Actions Workflows:

* [`.github/workflows/build-backend.yml`](diffhunk://#diff-36cac9d9547724bb7ce7af726016bc951d33caac93b17def37a1093633c49ab9R1-R24): Added a workflow to build the backend (server) component. This workflow runs on `ubuntu-latest`, checks out the code, sets up Node.js version 20, installs dependencies, and builds the server.

* [`.github/workflows/build-frontend.yml`](diffhunk://#diff-8a074f960f84b3877050c5f68141f31badf1a76dcc83b83d412ab6ff66a68cceR1-R24): Added a workflow to build the frontend (client) component. This workflow also runs on `ubuntu-latest`, checks out the code, sets up Node.js version 20, installs dependencies, and builds the client.